### PR TITLE
close response body after delete request

### DIFF
--- a/weedo.go
+++ b/weedo.go
@@ -229,7 +229,8 @@ func del(url string) error {
 	if err != nil {
 		return err
 	}
-	_, err = client.Do(request)
+	resp, err := client.Do(request)
+	resp.Body.Close()
 	return err
 }
 


### PR DESCRIPTION
If its not closed, you have lingering connections and can fill up number of open file descriptors.
