### PR TITLE
fix weed.Delete() crash bugs.

### DIFF
--- a/weedo.go
+++ b/weedo.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"mime/multipart"
 	"net/http"
@@ -262,7 +263,15 @@ func del(url string) error {
 		return err
 	}
 	resp, err := client.Do(request)
-	resp.Body.Close()
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		txt, _ := ioutil.ReadAll(resp.Body)
+		return errors.New(string(txt))
+	} else {
+		resp.Body.Close()
+	}
 	return err
 }
 

--- a/weedo.go
+++ b/weedo.go
@@ -266,11 +266,10 @@ func del(url string) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		txt, _ := ioutil.ReadAll(resp.Body)
 		return errors.New(string(txt))
-	} else {
-		resp.Body.Close()
 	}
 	return err
 }


### PR DESCRIPTION
a http post can be closed only if a `resp` is valid

This hanppend when an fid not exist or removed already.